### PR TITLE
Add absdiffby term; fix bug in checks for default values to optional …

### DIFF
--- a/R/updateModelTerms.R
+++ b/R/updateModelTerms.R
@@ -18,6 +18,7 @@
 #'    \item concurrent
 #'    \item degree
 #'    \item absdiff
+#'    \item absdiffby
 #'    \item nodecov
 #'    \item nodemix
 #'  }
@@ -248,6 +249,30 @@ updateModelTermInputs <- function(dat, network = 1) {
       # Transformation function
       pow <- args$pow
       inputs <- c(pow, dat$attr[[attrname]])
+      mf$terms[[t]]$inputs <- c(0, length(mf$terms[[t]]$coef.names),
+                                length(inputs), inputs)
+    }
+    
+    else if (term$name == "absdiffby") {
+      form <- dat$nwparam[[network]]$formation
+      args <- get_formula_term_args_in_formula_env(form, t)
+      attrname <- args[[1]]
+      byname <- args[[2]]
+      offset <- args[[3]]
+      values <- args[[4]]
+      if(length(values) != 2) {
+        stop(paste("\"by\" nodal attribute must be binary, and therefore should have 2 unique values. \nVector of values passed was of length ", length(values), sep = ""))
+      }
+      if(!all(values %in% unique(dat$attr[[byname]]))) {
+        stop(paste("Values of binary nodal attribute do not match those in formula term argument: \nValues in formula term argument:", 
+                   values[1], values[2], "\nValues of nodal attribute:", unique(dat$attr[[byname]])[1], unique(dat$attr[[byname]])[2], sep = " "))
+      }
+      if(!all(values == c(0, 1))) {
+        nodeby <- 1 * (dat$attr[[byname]] == values[2])
+      } else {
+        nodeby <- dat$attr[[byname]]
+      }
+      inputs <- c(offset, dat$attr[[attrname]], nodeby)
       mf$terms[[t]]$inputs <- c(0, length(mf$terms[[t]]$coef.names),
                                 length(inputs), inputs)
     }
@@ -553,8 +578,11 @@ get_formula_term_args_in_formula_env <- function(form, termIndex) {
   outlist <- eval(args, formula.env)
 
   # Set default base to 1
-  if (tname == "nodefactor" & is.null(outlist$base)) {
+  if (tname == "nodefactor" & length(outlist) == 1) {
     outlist$base <- 1
+  }
+  if (tname == "nodefactor" & length(outlist) == 2 & is.null(names(outlist)[2])) {
+    names(outlist)[2] <- "base"
   }
 
   # Set default pow to 1
@@ -564,11 +592,22 @@ get_formula_term_args_in_formula_env <- function(form, termIndex) {
   if (tname == "absdiff" & length(outlist) == 2 & is.null(names(outlist)[2])) {
     names(outlist)[2] <- "pow"
   }
+  
+  # Set default values in absdiffby to 0, 1
+  if (tname == "absdiffby" & length(outlist) == 3) {
+    outlist$values <- c(0, 1)
+  }
+  if (tname == "absdiffby" & length(outlist) == 4 & is.null(names(outlist)[4])) {
+    names(outlist)[4] <- "values"
+  }
 
   # set default fixed argument to FALSE
   # also needs default keep argument, set to NULL
-  if (tname == "nodematch" & is.null(args$diff)) {
+  if (tname == "nodematch" & length(outlist) == 1) {
     outlist$diff <- FALSE
+  }
+  if (tname == "nodematch" & length(outlist) == 2 & is.null(names(outlist)[2])) {
+    names(outlist)[2] <- "diff"
   }
 
   return(outlist)

--- a/tests/testthat/tests.R
+++ b/tests/testthat/tests.R
@@ -83,6 +83,60 @@ test_that("get_formula_term...", {
   args <- get_formula_term_args_in_formula_env(form, 2)
   expect_true(args[[1]] == "riskg")
   expect_true(names(args)[2] == "pow")
+  
+  # absdiffby
+  form <- ~edges + absdiffby("riskg", "by", "offset", values = c(0, 1))
+  args <- get_formula_term_args_in_formula_env(form, 2)
+  expect_true(args[[1]] == "riskg")
+  expect_true(args[[2]] == "by")
+  expect_true(args[[3]] == "offset")
+  expect_true(names(args)[4] == "values")
+  
+  form <- ~edges + absdiffby("riskg", "by", "offset", c(0, 1))
+  args <- get_formula_term_args_in_formula_env(form, 2)
+  expect_true(args[[1]] == "riskg")
+  expect_true(args[[2]] == "by")
+  expect_true(args[[3]] == "offset")
+  expect_true(names(args)[4] == "values")
+  
+  form <- ~edges + absdiffby("riskg", "by", "offset")
+  args <- get_formula_term_args_in_formula_env(form, 2)
+  expect_true(args[[1]] == "riskg")
+  expect_true(args[[2]] == "by")
+  expect_true(args[[3]] == "offset")
+  expect_true(names(args)[4] == "values")
+  
+  # nodefactor
+  form <- ~edges + nodefactor("riskg", base = 1)
+  args <- get_formula_term_args_in_formula_env(form, 2)
+  expect_true(args[[1]] == "riskg")
+  expect_true(names(args)[2] == "base")
+  
+  form <- ~edges + nodefactor("riskg", 1)
+  args <- get_formula_term_args_in_formula_env(form, 2)
+  expect_true(args[[1]] == "riskg")
+  expect_true(names(args)[2] == "base")
+  
+  form <- ~edges + nodefactor("riskg")
+  args <- get_formula_term_args_in_formula_env(form, 2)
+  expect_true(args[[1]] == "riskg")
+  expect_true(names(args)[2] == "base")
+  
+  # nodematch
+  form <- ~edges + nodematch("riskg", diff = F)
+  args <- get_formula_term_args_in_formula_env(form, 2)
+  expect_true(args[[1]] == "riskg")
+  expect_true(names(args)[2] == "diff")
+  
+  form <- ~edges + nodematch("riskg", F)
+  args <- get_formula_term_args_in_formula_env(form, 2)
+  expect_true(args[[1]] == "riskg")
+  expect_true(names(args)[2] == "diff")
+  
+  form <- ~edges + nodematch("riskg")
+  args <- get_formula_term_args_in_formula_env(form, 2)
+  expect_true(args[[1]] == "riskg")
+  expect_true(names(args)[2] == "diff")
 
 })
 


### PR DESCRIPTION
1. Added tergmLite version of ERGM term absdiffby
2. Fixed bug in get_formula_term_args_in_formula_env that would cause unnamed optional arguments to some terms to be evaluated to null even if an argument was provided.
3. Added unit tests for (2) above for terms absdiffby, nodefactor, and nodematch, following Sam's example for absdiff.