### PR TITLE
do not update mhd constraint for non-dynamic networks

### DIFF
--- a/R/updateModelTerms.R
+++ b/R/updateModelTerms.R
@@ -127,7 +127,6 @@ updateModelTermInputs <- function(dat, network = 1) {
     bd$minout <- matrix(rep(0, n), ncol = 1)
     bd$minin <- matrix(rep(0, n), ncol = 1)
     mhf$arguments$constraints$bd <- bd
-    mhd$arguments$constraints$bd <- bd
   }
 
   # MHproposal.diss (currently matches mhf bd constraint)


### PR DESCRIPTION
The line 130:

``` r
mhd$arguments$constraints$bd <- bd
```
produce en 'mhd' not found like error for non dynamic network

The same task is by the way done few lines after

``` r
if (dynamic == TRUE) {
    mhd$arguments$constraints$bd <- mhf$arguments$constraints$bd
  }
```
So it is safe just to remove it.