### PR TITLE
make tergmLite pass R CMD check with statnet master branches

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -58,6 +58,11 @@ networkLite <- function(el, attr) {
     stop("networkLite constructor requires network size attribute.")
   }
 
+  ## for consistency with network,
+  ## we want x$gal$n to be of type
+  ## numeric, not integer
+  x$gal$n <- as.numeric(x$gal$n)
+
   # other common attributes default to FALSE
   if (is.null(x$gal$directed))  {
     x$gal$directed <- FALSE


### PR DESCRIPTION
It turns out `network`s return a `numeric` when you call `network.size` on them, while `networkLite`s constructed from `edgelist`s (whose `n` attribute is of class `integer`, as of statnet/network@d47fa2046c621290bf5e053d5de0c2f48471ffe8) would return an `integer`.  This generated the test failures referred to in statnet/EpiModel#427.  With the update in this PR, both `tergmLite` and `EpiModel` master pass `R CMD check` for me.  (I am not familiar with the scripts referred to in statnet/EpiModel#427 so I have not tested those.)

In the longer term we might want to consider changing the behavior of `network` so it returns an `integer` (since network size should be an integer), but for now this should work.

